### PR TITLE
Print array if a quantity value is of array type and shorter than 4 in length

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-  implementation 'org.codehaus.groovy:groovy:2.5.9'
+  implementation 'org.codehaus.groovy:groovy:2.5.20'
   implementation 'com.github.org-arl:fjage:1.11.0'
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.spockframework:spock-core:1.0-groovy-2.4'

--- a/src/main/groovy/org/arl/fjage/sentuator/Quantity.groovy
+++ b/src/main/groovy/org/arl/fjage/sentuator/Quantity.groovy
@@ -27,7 +27,10 @@ class Quantity {
   @Override
   String toString() {
     if (value == null) return null
-    String vstr = value.class.isArray() ? '<data>' : value.toString()
+    String vstr = value.toString()
+    if (value.class.isArray()){
+      vstr = (value as Object[]).size() > 3 ? "<data>" : "[" + value.collect{it.toString()}.join(", ") + "]"
+    }
     if (units == null) return vstr
     return "$vstr $units"
   }


### PR DESCRIPTION
Print array if a quantity value is of array type and shorter than 4.

This makes visualizing `GenericMeasurement` and other Measurements with short arrays easier.

Before..

```
GenericMeasurement[... angular-velocity:<data> rad/s ...]
```

Now..

```
GenericMeasurement[... angular-velocity:[0.0, 0.0, 0.0] rad/s ...]
```